### PR TITLE
fix: Fixed the bug to use the variable expansion

### DIFF
--- a/src/parse/aux/string_argument/string_argument.c
+++ b/src/parse/aux/string_argument/string_argument.c
@@ -26,11 +26,11 @@ static int	variable(t_arg *arg, char *string, char **envp)
 	int		var_size;
 	int		i;
 
-	var_size = arg->i + 1;
+	var_size = ++arg->i;
 	while (string[var_size] && is_var_char(string[var_size]))
 		var_size++;
-	var_size -= (arg->i + 1);
-	name = ft_substr(string + arg->i + 1, 0, var_size);
+	var_size -= (arg->i);
+	name = ft_substr(string + arg->i, 0, var_size);
 	if (!name)
 		return (free(arg->string), 0);
 	prefix = ft_strjoin(name, "=");
@@ -76,6 +76,3 @@ char	*string_argument(char *string, char **envp, int *len, int to_expand)
 		*len += arg.i;
 	return (arg.string);
 }
-//  echo 'hel' $SHELL 'lo'
-//  "e"c'h'"o" "hel' $SHELL 'lo"
-//  "e"c'h'"o" hel' $SHELL 'lo


### PR DESCRIPTION
### The bug

The bug was when enter at the function **variable**, it returns the size of the variable name, but was not including the dollar sign ($).

### The fix

Instead of use `arg->i + 1`, now is changed to use `++arg->i`, this would increase value before, to use the correct way with this, and set as well the size name of the variable.

**Others:**

- Remove comments.