### PR TITLE
fix: Fixed the parse of token to handle backslash and white spaces

### DIFF
--- a/src/parse/aux/string_argument/string_argument.c
+++ b/src/parse/aux/string_argument/string_argument.c
@@ -55,7 +55,7 @@ char	*string_argument(char *string, char **envp, int *len, int to_expand)
 	if (!arg.string)
 		return (NULL);
 	arg.i = -1;
-	while (string[++arg.i] && arg.pos < arg.lstring)
+	while (string[++arg.i] && arg.pos <= arg.lstring)
 	{
 		if (is_tohandle_backslash(string + arg.i, arg.quotes.quote))
 			arg.i++;
@@ -68,8 +68,7 @@ char	*string_argument(char *string, char **envp, int *len, int to_expand)
 			break ;
 		if (is_to_handle_variable(&arg, string, envp, to_expand))
 			arg.i = variable(&arg, string, envp);
-		else
-			arg.string[arg.pos++] = string[arg.i];
+		arg.string[arg.pos++] = string[arg.i];
 	}
 	arg.string[arg.pos] = '\0';
 	if (len && to_expand)

--- a/src/parse/aux/string_argument/string_argument_size.c
+++ b/src/parse/aux/string_argument/string_argument_size.c
@@ -44,7 +44,7 @@ int	string_argument_size(char *string, char **envp, int to_expand, int is_hdoc)
 	i = -1;
 	while (string[++i])
 	{
-		if (is_tohandle_backslash(string + i, quotes.quote))
+		if (is_tohandle_backslash(string + jumps + i, quotes.quote))
 			jumps += 1;
 		if (is_main_quote_closed(&quotes) && get_operator(string + i) && !is_hdoc)
 			break ;


### PR DESCRIPTION
Fixed the situations on below:

```
echo "      " // Error when has spaces
echo "$USER ola" // Jump the character after variable 
echo "\\\\" // Not handling correct the backslash
``` 