### PR TITLE
fix: Reset the struct arg after used in function

### DIFF
--- a/src/parse/aux/string_argument/string_argument_size.c
+++ b/src/parse/aux/string_argument/string_argument_size.c
@@ -58,4 +58,5 @@ void	string_argument_size(t_arg *arg, char *string, char **envp)
 //	if (!is_quote_closed(&arg->quotes))
 //		printf("Command not found\n");
 	arg->lstring -= jumps;
+	arg->quotes = (t_quotes){};
 }


### PR DESCRIPTION
### Conflict between the same struct 

Reset the struct arg after used in function string_argument_size, for not get the trash used on function string_argument