### PR TITLE
fix: ft_exit to be builtin and free all

### DIFF
--- a/include/execute.h
+++ b/include/execute.h
@@ -35,7 +35,7 @@ int		is_parent_builtin(t_head *head, t_btree *btree);
 void	call_builtin(t_head *head, t_btree *node);
 int		ft_pwd(t_btree *node);
 int		ft_cd(char *path);
-void		ft_exit(t_head *head);
+void		ft_exit(t_head *head, t_btree *node);
 
 //signals
 void	signal_handler(void);

--- a/src/builtin/aux/builtin.c
+++ b/src/builtin/aux/builtin.c
@@ -44,7 +44,7 @@ int	is_parent_builtin(t_head *head, t_btree *node)
 		return (1);
 	if (!ft_strncmp("exit", command, ft_strlen("exit")) && head->n_cmds == 1)
 	{
-		ft_exit(head);
+		ft_exit(head, node);
 		return (0);
 	}
 	if (!ft_strncmp("cd", command, ft_strlen("cd")))

--- a/src/builtin/ft_exit.c
+++ b/src/builtin/ft_exit.c
@@ -1,9 +1,18 @@
 
 #include "minishell.h"
 
-void	ft_exit(t_head *head)
+void	ft_exit(t_head *head, t_btree *node)
 {
 	free_db_str(head->env.vars);
 //	head = NULL;
 	ft_putendl_fd("exit", 1);
+	if (node)
+	{
+		close_all(head, node, NULL);
+		free_node(node);
+	}
+	close(head->files.in.fd);
+	close(head->files.out.fd);
+	end(head, 0, "SUCESS");
+	exit (0);
 }

--- a/src/minishell.c
+++ b/src/minishell.c
@@ -10,10 +10,7 @@ int	minishell(t_head *head)
 //		signal_handler();
 		prompt = readline("\001\033[1;92m\002minishell\001\033[1;94m\002> \001\033[0;39m\002");
 		if (!prompt)
-		{
-			ft_exit(head);
-			break ;
-		}
+			ft_exit(head, NULL);
 		if (!(*prompt))
 			continue ;
 		add_history(prompt);


### PR DESCRIPTION
Fix: ft_exit to free all, work as a builtin and also with crtl+d